### PR TITLE
Fix catalog workflow

### DIFF
--- a/.github/workflows/catalog.yaml
+++ b/.github/workflows/catalog.yaml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Enable QEMU
+        run: sudo apt install qemu-user-static
+
       - name: Login to quay.io/3scale
         uses: redhat-actions/podman-login@v1
         with:


### PR DESCRIPTION
Installs system package `qemu-user-static` in the GH workflow VM so the multi-platform catalog image can be built.

/kind fix
/priority important-soon
/assign