### PR TITLE
Automate api/ module tag in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,3 +43,8 @@ jobs:
           automatic_release_tag: "${{ env.NEW_RELEASE }}"
           title: "${{ env.NEW_RELEASE }}"
           draft: true
+
+      - name: Add the tag for the api module
+        if: ${{ env.NEW_RELEASE != '' }}
+        run: |
+          git tag api/${{ env.NEW_RELEASE }} && git push origin api/${{ env.NEW_RELEASE }}


### PR DESCRIPTION
As stated in
https://go.dev/doc/modules/managing-source#multiple-module-source,
having multiple go modules in a repo requires a specific tag for each
one of them.
This step was missing from the release workflow.

/kind fix
/priority important soon
/assign