### PR TITLE
Add missing workflow permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   check:


### PR DESCRIPTION
Yet another fix for the release workflow. Needs specific pull-request write permissions.

/kind fix
/priority important-soon
/assign